### PR TITLE
feat: qmk caps word

### DIFF
--- a/app/src/behaviors/behavior_caps_word.c
+++ b/app/src/behaviors/behavior_caps_word.c
@@ -119,7 +119,9 @@ static bool caps_word_is_numeric(uint8_t usage_id) {
 
 static void caps_word_enhance_usage(const struct behavior_caps_word_config *config,
                                     struct zmk_keycode_state_changed *ev) {
-    if (ev->usage_page != HID_USAGE_KEY || !caps_word_is_alpha(ev->keycode)) {
+    if (ev->usage_page != HID_USAGE_KEY ||
+        !(caps_word_is_alpha(ev->keycode) ||
+          ev->keycode == HID_USAGE_KEY_KEYBOARD_MINUS_AND_UNDERSCORE)) {
         return;
     }
 

--- a/app/tests/caps-word/continue-with-modifiers/keycode_events.snapshot
+++ b/app/tests/caps-word/continue-with-modifiers/keycode_events.snapshot
@@ -5,9 +5,10 @@ released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
 release: Modifiers set to 0x00
 pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
 press: Modifiers set to 0x02
+enhance_usage: Enhancing usage 0x2D with modifiers: 0x02
 caps_includelist: Comparing with 0x07 - 0x2D (with implicit mods: 0x02)
 caps_includelist: Continuing capsword, found included usage: 0x07 - 0x2D
-pressed: usage_page 0x07 keycode 0x2D implicit_mods 0x00 explicit_mods 0x00
+pressed: usage_page 0x07 keycode 0x2D implicit_mods 0x02 explicit_mods 0x00
 press: Modifiers set to 0x02
 released: usage_page 0x07 keycode 0x2D implicit_mods 0x00 explicit_mods 0x00
 release: Modifiers set to 0x02

--- a/app/tests/caps-word/continue-with-non-alpha-continue-list-item/keycode_events.snapshot
+++ b/app/tests/caps-word/continue-with-non-alpha-continue-list-item/keycode_events.snapshot
@@ -3,11 +3,11 @@ pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x02 explicit_mods 0x00
 press: Modifiers set to 0x02
 released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
 release: Modifiers set to 0x00
+enhance_usage: Enhancing usage 0x2D with modifiers: 0x02
 caps_includelist: Comparing with 0x07 - 0x2D (with implicit mods: 0x02)
-caps_includelist: Comparing with 0x07 - 0x2D (with implicit mods: 0x00)
 caps_includelist: Continuing capsword, found included usage: 0x07 - 0x2D
-pressed: usage_page 0x07 keycode 0x2D implicit_mods 0x00 explicit_mods 0x00
-press: Modifiers set to 0x00
+pressed: usage_page 0x07 keycode 0x2D implicit_mods 0x02 explicit_mods 0x00
+press: Modifiers set to 0x02
 released: usage_page 0x07 keycode 0x2D implicit_mods 0x00 explicit_mods 0x00
 release: Modifiers set to 0x00
 enhance_usage: Enhancing usage 0x04 with modifiers: 0x02

--- a/app/tests/caps-word/deactivate-by-non-alpha-non-continuation/keycode_events.snapshot
+++ b/app/tests/caps-word/deactivate-by-non-alpha-non-continuation/keycode_events.snapshot
@@ -3,11 +3,13 @@ pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x02 explicit_mods 0x00
 press: Modifiers set to 0x02
 released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
 release: Modifiers set to 0x00
-pressed: usage_page 0x07 keycode 0x2D implicit_mods 0x00 explicit_mods 0x00
-press: Modifiers set to 0x00
+enhance_usage: Enhancing usage 0x2D with modifiers: 0x02
+pressed: usage_page 0x07 keycode 0x2D implicit_mods 0x02 explicit_mods 0x00
+press: Modifiers set to 0x02
 released: usage_page 0x07 keycode 0x2D implicit_mods 0x00 explicit_mods 0x00
 release: Modifiers set to 0x00
-pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
-press: Modifiers set to 0x00
+enhance_usage: Enhancing usage 0x04 with modifiers: 0x02
+pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x02 explicit_mods 0x00
+press: Modifiers set to 0x02
 released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
 release: Modifiers set to 0x00


### PR DESCRIPTION
<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [ ] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).

Mimic QMK capsword behavior, minus becomes underscore during capsword